### PR TITLE
style: sidebar tooltip fixes; sign out button separation

### DIFF
--- a/components/admin/sidebar.tsx
+++ b/components/admin/sidebar.tsx
@@ -39,13 +39,14 @@ const NAV_ITEMS: NavItem[] = [
     href: "/admin/approval",
     icon: FileText,
   },
-  {
-    label: "Sign Out",
-    href: "/",
-    icon: LogOut,
-    exact: true,
-  },
 ];
+
+const SIGN_OUT_ITEM: NavItem = {
+  label: "Sign Out",
+  href: "/",
+  icon: LogOut,
+  exact: true,
+};
 
 export function Sidebar() {
   const pathname = usePathname();
@@ -155,6 +156,41 @@ export function Sidebar() {
           );
         })}
       </nav>
+
+      {/* Sign Out Button - Separated at bottom */}
+      <Link
+        href={SIGN_OUT_ITEM.href}
+        className={`
+          group relative flex items-center font-bold transition-all duration-200
+          ${
+            isExpanded
+              ? "justify-between rounded-lg p-3 px-4"
+              : "justify-center rounded-full p-2"
+          }
+          text-yellow-100 hover:bg-black/20 hover:text-yellow-500
+        `}
+      >
+        {isExpanded && (
+          <span className="mr-4 flex-1 whitespace-nowrap text-right text-yellow-500">
+            {SIGN_OUT_ITEM.label}
+          </span>
+        )}
+        <div className="flex h-10 w-10 items-center justify-center rounded-full bg-[#993333] transition-colors">
+          <LogOut className="h-5 w-5 text-[#360000]" />
+        </div>
+        {!isExpanded && (
+          <span
+            className="
+              pointer-events-none absolute left-full top-1/2 z-50 ml-2 -translate-y-1/2
+              rounded-md border border-yellow-300/70 bg-yellow-100 px-3 py-1
+              text-xs font-semibold uppercase tracking-wide text-[#360000] shadow-lg
+              opacity-0 transition-opacity duration-200 group-hover:opacity-100
+            "
+          >
+            {SIGN_OUT_ITEM.label}
+          </span>
+        )}
+      </Link>
     </aside>
   );
 }


### PR DESCRIPTION
## Description
- fixed z-index for tooltip when hovering a nav item in sidebar
- remove the native tooltip popup
- moved sign out button to the bottom, to separate it from other actions. (like in #66)

## Related Issues
Closes #<issue-number>

## Changes
- [ ] Feature added
- [x] Bug fixed
- [ ] Documentation updated

## Testing
http://localhost:3000/admin/publication

## Checklist
- [ ] Code compiles and runs
- [ ] Tests added or updated
- [ ] PR title follows conventional commits

---

### Before
<img width="414" height="130" alt="image" src="https://github.com/user-attachments/assets/42ffac7e-55dd-44d7-88d7-3e1a3327bdbd" />

### After
<img width="290" height="104" alt="image" src="https://github.com/user-attachments/assets/aa12a603-11dc-4849-80fc-a316dd45d9b6" />